### PR TITLE
chore: KeyboardInterrupt exit & clear terminal

### DIFF
--- a/aivilization/main.py
+++ b/aivilization/main.py
@@ -1,4 +1,5 @@
 import readline
+import os
 
 from core.civilization import Civilization
 from core.civilization.person.tracer.log import LogTracer
@@ -14,18 +15,26 @@ def get_default_tracers():
     return default_tracers
 
 
+def clear_terminal():
+    os.system("cls" if os.name == "nt" else "clear")
+
+
 def main():
     civilization = Civilization(default_tracers=get_default_tracers())
 
     while True:
         try:
             problem = input(">>> ")
+
+            if problem == "clear":
+                clear_terminal()
+                continue
+
             civilization.solve(problem)
 
             readline.add_history(problem)
         except KeyboardInterrupt:
-            print()
-            continue
+            os._exit(0)
         except EOFError:
             logger.info("Bye!")
             break


### PR DESCRIPTION
Adds `KeyboardInterrupt()` and `clear()` terminal commands for enhanced functionality:
- `KeyboardInterrupt()` allows exiting terminal immediately
- `clear()` command clears the terminal screen for better user experience.